### PR TITLE
[make & configure] Don't strip leading underscore on Win64

### DIFF
--- a/tools/llvm-shlib/Makefile
+++ b/tools/llvm-shlib/Makefile
@@ -86,11 +86,19 @@ $(LibName.SO): $(SHLIB_STUBS)
 	$(Echo) Collecting global symbols of $(notdir $*)
 	$(Verb) $(NM_PATH) -g $< > $@
 
+# The Windows ABI specifies leading underscores only on 32bit, so
+# make sure we don't strip them on x86_64
+ifeq ($(ARCH),x86_64)
+ABI_UNDERSCORE =
+else
+ABI_UNDERSCORE =_
+endif
+
 $(ObjDir)/$(LIBRARYNAME).exports: $(SHLIB_FRAGS) $(ObjDir)/.dir
 	$(Echo) Generating exports for $(LIBRARYNAME)
 	$(Verb) ($(SED) -n \
-			-e "s/^.* T _\([^.][^.]*\)$$/\1/p" \
-			-e "s/^.* [BDR] _\([^.][^.]*\)$$/\1 DATA/p" \
+			-e "s/^.* T $(ABI_UNDERSCORE)\([^.][^.]*\)$$/\1/p" \
+			-e "s/^.* [BDR] $(ABI_UNDERSCORE)\([^.][^.]*\)$$/\1 DATA/p" \
 			$(SHLIB_FRAGS) \
 		 | sort -u) > $@
 


### PR DESCRIPTION
since we'll have to be running the magical toys off of a branch for the near future anyway. @Keno

ref: http://reviews.llvm.org/D5036